### PR TITLE
Add missing semicolons

### DIFF
--- a/www/discoresponse.html
+++ b/www/discoresponse.html
@@ -44,7 +44,7 @@ function receive() {
 		
 		rsearch = urlParams.entityID.match(/^(.*)#(.*)$/);
 		if (rsearch) {
-			idpentityid = rsearch[1]
+			idpentityid = rsearch[1];
 			subid = rsearch[2];
 		} else {
 			idpentityid = urlParams.entityID;

--- a/www/res/js2/controllers/DateColumnEditor.js
+++ b/www/res/js2/controllers/DateColumnEditor.js
@@ -370,7 +370,7 @@ define(function(require, exports) {
 		}
 
 
-	})
+	});
 
 	return DateColumnEditor;
 

--- a/www/res/js2/controllers/EditFoodleController.js
+++ b/www/res/js2/controllers/EditFoodleController.js
@@ -450,7 +450,7 @@ define(function(require, exports) {
 
 				if (this.foodle.restrictions.rows) {
 					this.el.find('#enableRestrictionRowlimit').prop('checked', true);
-					this.el.find('#inputRestrictionRowlimit').val(this.foodle.restrictions.rows)
+					this.el.find('#inputRestrictionRowlimit').val(this.foodle.restrictions.rows);
 
 				} else {
 					this.el.find('#enableRestrictionRowlimit').prop('checked', false);
@@ -474,7 +474,7 @@ define(function(require, exports) {
 
 				if (this.foodle.restrictions.checklimit) {
 					this.el.find('#enableRestrictionCheckLimit').prop('checked', true);
-					this.el.find('#inputRestrictionCheckLimit').val(this.foodle.restrictions.checklimit)
+					this.el.find('#inputRestrictionCheckLimit').val(this.foodle.restrictions.checklimit);
 
 				} else {
 					this.el.find('#enableRestrictionCheckLimit').prop('checked', false);

--- a/www/res/js2/controllers/FoodleResponseController.js
+++ b/www/res/js2/controllers/FoodleResponseController.js
@@ -551,7 +551,7 @@ define(function(require, exports) {
 					s.val(tz);
 					that.setTimezone(tz);
 				}
-			})
+			});
 
 			// for(var i = 0; i < window.moment_zones.length; i++) {
 			// 	s.append('<option>' + moment_zones[i] + '</option>');

--- a/www/res/js2/controllers/TextColumnEditor.js
+++ b/www/res/js2/controllers/TextColumnEditor.js
@@ -291,7 +291,7 @@ define(function(require, exports) {
 				} 
 
 			}	
-			console.log("Summary", this.topcolumns, this.subcolumns)
+			console.log("Summary", this.topcolumns, this.subcolumns);
 			console.log("-----");
 
 		},

--- a/www/res/uninett-theme-bootstrap/js/holder.js
+++ b/www/res/uninett-theme-bootstrap/js/holder.js
@@ -431,7 +431,7 @@ var Holder = Holder || {};
                 .split("/"), options);
                 if (holder) {
                     if (holder.fluid) {
-                        render("fluid", images[i], holder, src)
+                        render("fluid", images[i], holder, src);
                     } else {
                         render("image", images[i], holder, src);
                     }


### PR DESCRIPTION
That fixes some issues reported by LGTM:

    Avoid automated semicolon insertion (97% of all statements
    in the enclosing function have an explicit semicolon).

Signed-off-by: Stefan Weil <sw@weilnetz.de>